### PR TITLE
(fix) Add required tokens

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -50,7 +50,7 @@
 	},
 	"dependencies": {
 		"prettier": "^2.7.1",
-		"jinx-rust": "^0.1.4",
+		"jinx-rust": "0.1.5",
 		"prettier-plugin-rust": "file:../"
 	},
 	"main": "index.js",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"jinx-rust": "^0.1.4",
+		"jinx-rust": "0.1.5",
 		"prettier": "^2.7.1"
 	},
 	"prettier": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,13 @@ importers:
     specifiers:
       '@types/node': ^18.0.6
       '@types/prettier': ^2.6.3
-      jinx-rust: ^0.1.4
+      jinx-rust: 0.1.5
       prettier: ^2.7.1
       ts-node: ^10.9.1
       tsup: ^6.1.3
       typescript: ^4.7.4
     dependencies:
-      jinx-rust: 0.1.4
+      jinx-rust: 0.1.5
       prettier: 2.7.1
     devDependencies:
       '@types/node': 18.6.1
@@ -44,13 +44,13 @@ importers:
       '@types/node': ^18.0.6
       '@types/vscode': ^1.69.0
       esbuild: ^0.14.49
-      jinx-rust: ^0.1.4
+      jinx-rust: 0.1.5
       prettier: ^2.7.1
       prettier-plugin-rust: file:../
       tsup: ^6.1.3
       typescript: ^4.7.4
     dependencies:
-      jinx-rust: 0.1.4
+      jinx-rust: 0.1.5
       prettier: 2.7.1
       prettier-plugin-rust: 'file:'
     devDependencies:
@@ -652,8 +652,8 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /jinx-rust/0.1.4:
-    resolution: {integrity: sha512-Tp4TewXfwFi/OVlDz/uz5tRx11cPvgzD4nFgt+DtLCuICCGiQr8M8TY9xqtKQGHXB7ho115Zf3sxOYjJO9kwcA==}
+  /jinx-rust/0.1.5:
+    resolution: {integrity: sha512-nhahqeGsdpW8JrNAPbPov8vsUnUVziKMFpUDgvFsxUuNH0XRYsfsVp77H17sI9CPGs0S/I8KZEs2i6dX8xzdqA==}
     dev: false
 
   /joycon/3.1.1:
@@ -1120,8 +1120,8 @@ packages:
   'file:':
     resolution: {directory: '', type: directory}
     name: prettier-plugin-rust
-    version: 0.1.2
+    version: 0.1.5
     dependencies:
-      jinx-rust: 0.1.4
+      jinx-rust: 0.1.5
       prettier: 2.7.1
     dev: false

--- a/src/format/core.ts
+++ b/src/format/core.ts
@@ -92,7 +92,6 @@ import {
 	is_ExpressionStatement,
 	is_ExpressionTypeCast,
 	is_ExpressionWithBodyOrCases,
-	is_ExpressionWithBodyOrCases_or_BlockLikeMacroInvocation,
 	is_FlowControlExpression,
 	is_FunctionDeclaration,
 	is_FunctionParameterDeclaration,
@@ -295,10 +294,7 @@ export function printBodyOrCases<T extends NodeWithBodyOrCases | BlockLikeMacroI
 		pathCallEach(node as Extract<Node, MatchExpression>, "cases", (mCase) => {
 			p.push({
 				node: mCase,
-				doc:
-					is_MatchExpressionCase(mCase) && !is_ExpressionWithBodyOrCases_or_BlockLikeMacroInvocation(mCase.expression)
-						? [print(), ","]
-						: print(),
+				doc: is_MatchExpressionCase(mCase) && !is_ExpressionWithBodyOrCases(mCase.expression) ? [print(), ","] : print(),
 			});
 		});
 	} else {

--- a/src/format/styling.ts
+++ b/src/format/styling.ts
@@ -86,6 +86,7 @@ import {
 	is_TypeFunctionNode,
 	is_TypeTraitBound,
 	is_UnaryExpression,
+	is_UnaryType,
 	is_UnionPattern,
 	is_WhileBlockExpression,
 	is_YieldExpression,
@@ -288,14 +289,12 @@ export function needsInnerParens(node: Node) {
 	}
 
 	if (is_TypeBoundsStandaloneNode(node)) {
-		if (
+		return (
+			(is_UnaryType(parent) && node.typeBounds.length > 1) ||
 			is_TypeBoundsStandaloneNode(parent) ||
 			is_TypeTraitBound(parent) ||
 			(is_TypeFunctionNode(parent) && parent.returnType === node)
-		) {
-			return true;
-		}
-		return false;
+		);
 	}
 
 	if (is_PatternVariableDeclaration(parent)) {

--- a/tests/output-ext/expressions/expr.f.rs
+++ b/tests/output-ext/expressions/expr.f.rs
@@ -158,7 +158,7 @@ fn main() {
   // std::<_ as _>,
   std::<0>,
   &raw const x,
-  (A::a as fn(&dyn A + 'static) -> B)(&"c"),
+  (A::a as fn(&(dyn A + 'static)) -> B)(&"c"),
   f::<<T as S>::E>(),
   <u64 as From<<T as Iterator>::Item>>::from(),
   <<Q as A<'_>>::B as C<Q::D>>::e(db),

--- a/tests/output-ext/types/types.f.rs
+++ b/tests/output-ext/types/types.f.rs
@@ -71,8 +71,8 @@ fn f1<'a, 'b, 'c>(_x: &'a u32, _y: &'b u32, _z: &'c u32) where 'c: 'a + 'b {}
 fn syntax() {
   A::<T = u8, T: Ord, String>();
   A::<T = u8, 'a, T: Ord>();
-  fn y<'a>(y: &mut dyn 'a + Send);
-  let z = y as &mut dyn 'a + Send;
+  fn y<'a>(y: &mut (dyn 'a + Send));
+  let z = y as &mut (dyn 'a + Send);
   let x: &'static str = "A";
   fn A() -> Box<<Self as A>::T>;
   let a = |a, b: _| -> _ { 0 };
@@ -93,7 +93,7 @@ fn syntax() {
   let a: Box<impl A + B + C>;
   let a: Box<impl A + B + C + D>;
   let a: Box<dyn A + B + C + D + E>;
-  let a: &dyn for<'a> Trait<'a> + 'static;
+  let a: &(dyn for<'a> Trait<'a> + 'static);
   let a: &dyn PartialEq<u32> = &7u32;
   let a: Option<!> = None;
   let a = &() as *const () as *const Bottom;

--- a/tests/output/issues/0.f.rs
+++ b/tests/output/issues/0.f.rs
@@ -2231,4 +2231,17 @@ const f = static async |source, block, opts| {
     };
   }
 };
+
+type Expect_Parenthesized_dyn = Pin<&mut (dyn Future<Output = T> + Send)>;
+
+let mut Expect_Comma_after_first_match = match 0 {
+  RuntimeFlavor::CurrentThread =>
+    quote_spanned! {last_stmt_start_span=>
+        #crate_ident::runtime::Builder::new_current_thread()
+    },
+  RuntimeFlavor::Threaded =>
+    quote_spanned! {last_stmt_start_span=>
+        #crate_ident::runtime::Builder::new_multi_thread()
+    },
+};
 // source: "../../samples/issues/0.rs"

--- a/tests/samples/issues/0.rs
+++ b/tests/samples/issues/0.rs
@@ -1909,3 +1909,14 @@ const f = static async |source, block, opts| {
   }
 };
 
+
+type Expect_Parenthesized_dyn = Pin<&mut (dyn Future<Output = T> + Send)>;
+
+let mut Expect_Comma_after_first_match = match 0 {
+    RuntimeFlavor::CurrentThread => quote_spanned! {last_stmt_start_span=>
+        #crate_ident::runtime::Builder::new_current_thread()
+    },
+    RuntimeFlavor::Threaded => quote_spanned! {last_stmt_start_span=>
+        #crate_ident::runtime::Builder::new_multi_thread()
+    },
+};


### PR DESCRIPTION
- Adds required parenthesis around >1 length standalone type bounds (dyn, impl) nested in unary types.
- Adds required comma for `MatchExpression.expression` when expression is a block-like Macro invocation. 