### PR TITLE
(fix) StructLiteralPropertySpread trailing comma

### DIFF
--- a/src/format/core.ts
+++ b/src/format/core.ts
@@ -2279,7 +2279,7 @@ export function printObject<T extends ObjectNode>(print: print<T>, node: T): Doc
 			...print.join(
 				"properties", //
 				(node) => (isNextLineEmpty(node) ? [",", hardline, hardline] : [",", line]),
-				ifBreak(",")
+				(node) => (is_StructLiteralPropertySpread(node) ? "" : ifBreak(","))
 			),
 		]),
 		line,

--- a/tests/output/common/chains.last-argument-expansion.f.rs
+++ b/tests/output/common/chains.last-argument-expansion.f.rs
@@ -176,7 +176,7 @@ const formatData = pipe(
   zip,
   map(|[ref a, data]| A {
     nodeId: a.nodeId.toString(),
-    ..attributeFromDataValue(a.attributeId, data),
+    ..attributeFromDataValue(a.attributeId, data)
   }),
   groupBy(prop("nodeId")),
   map(mergeAll),
@@ -184,8 +184,8 @@ const formatData = pipe(
 );
 
 const setProp = |y| A {
-  ..y,
   a: "very, very, very long very, very long text",
+  ..y
 };
 
 const log = |y| { console.log("very, very, very long very, very long text") };

--- a/tests/output/common/types.f.rs
+++ b/tests/output/common/types.f.rs
@@ -337,7 +337,7 @@ let listener = DOM.listen(
   |event: JavelinEvent| -> void {
     BanzaiLogger.log(config, A {
       ..logData,
-      ..DataStore.get(event.getNode(sigil)),
+      ..DataStore.get(event.getNode(sigil))
     })
   }
 );

--- a/tests/output/issues/0.f.rs
+++ b/tests/output/issues/0.f.rs
@@ -2244,4 +2244,9 @@ let mut Expect_Comma_after_first_match = match 0 {
         #crate_ident::runtime::Builder::new_multi_thread()
     },
 };
+
+ExpectNoSpreadComma { ..a };
+ExpectNoSpreadComma { ..a };
+ExpectNoSpreadComma { a, b: b, ..c };
+ExpectNoSpreadComma { a, b: b, ..c };
 // source: "../../samples/issues/0.rs"

--- a/tests/samples/issues/0.rs
+++ b/tests/samples/issues/0.rs
@@ -1920,3 +1920,8 @@ let mut Expect_Comma_after_first_match = match 0 {
         #crate_ident::runtime::Builder::new_multi_thread()
     },
 };
+
+ExpectNoSpreadComma { ..a };
+ExpectNoSpreadComma { ..a, };
+ExpectNoSpreadComma { a, b: b, ..c };
+ExpectNoSpreadComma { a, ..c, b: b };


### PR DESCRIPTION
- Removes forbidden trailing comma after `StructLiteralPropertySpread`
- Moves `StructLiteralPropertySpread` to the end of struct literals