### PR TITLE
(fix) RestUnassigned trailing comma

### DIFF
--- a/src/format/comments.ts
+++ b/src/format/comments.ts
@@ -24,6 +24,7 @@ import {
 	is_ReassignmentNode,
 	is_StatementNode,
 	is_StructLiteralProperty,
+	is_StructLiteralPropertySpread,
 	nisAnyOf,
 	ownStart,
 	start,
@@ -424,6 +425,7 @@ function handleCommon(ctx: CommentContext): boolean {
 		handleDanglingComments,
 		handleFunctionComments,
 		handleMacroRuleComments,
+		handleStructLiteralComments,
 		handleVariableDeclaratorComments,
 		handleIfBlockExpressionComments,
 		handleMemberExpressionComments,
@@ -499,6 +501,13 @@ export function handleEndOfLineComment(ctx: CommentContext) {
 export function handleRemainingComment(ctx: CommentContext) {
 	return handleCommon(ctx);
 }
+
+function handleStructLiteralComments({ precedingNode, enclosingNode, followingNode, comment, ast }: CommentContext) {
+	if (enclosingNode && is_StructLiteralPropertySpread(enclosingNode) && followingNode === enclosingNode.expression) {
+		addLeadingComment(enclosingNode, comment);
+	}
+}
+
 function handleVariableDeclaratorComments({ precedingNode, enclosingNode, followingNode, comment, ast }: CommentContext) {
 	if (
 		enclosingNode &&

--- a/src/format/core.ts
+++ b/src/format/core.ts
@@ -47,9 +47,12 @@ import {
 	PatternNode,
 	PunctuationToken,
 	RangeNode,
+	RestPattern,
 	ReturnExpression,
 	StructDeclaration,
 	StructLiteral,
+	StructLiteralPropertySpread,
+	StructLiteralRestUnassigned,
 	TK,
 	TraitAliasDeclaration,
 	TraitDeclaration,
@@ -241,6 +244,18 @@ export function is_BinaryishExpression(node: Node): node is OrExpression | AndEx
 		case NodeType.AndExpression:
 		case NodeType.OperationExpression:
 		case NodeType.ComparisonExpression:
+			return true;
+		default:
+			return false;
+	}
+}
+
+export type StructSpread = StructLiteralPropertySpread | StructLiteralRestUnassigned | RestPattern;
+export function is_StructSpread(node: Node): node is StructSpread {
+	switch (node.nodeType) {
+		case NodeType.StructLiteralPropertySpread:
+		case NodeType.StructLiteralRestUnassigned:
+		case NodeType.RestPattern:
 			return true;
 		default:
 			return false;
@@ -2279,7 +2294,7 @@ export function printObject<T extends ObjectNode>(print: print<T>, node: T): Doc
 			...print.join(
 				"properties", //
 				(node) => (isNextLineEmpty(node) ? [",", hardline, hardline] : [",", line]),
-				(node) => (is_StructLiteralPropertySpread(node) ? "" : ifBreak(","))
+				(node) => (is_StructSpread(node) ? "" : ifBreak(","))
 			),
 		]),
 		line,

--- a/tests/output-ext/macro/macro.invocation.f.rs
+++ b/tests/output-ext/macro/macro.invocation.f.rs
@@ -70,11 +70,11 @@ fn main() {
             StmtKind::Local(Local {
               pat: Pat {
                 kind: PatKind::Wild,
-                ..,
+                ..
               },
-              ..,
+              ..
             }),
-            ..,
+            ..
           }),
           _,
         ))

--- a/tests/output/comments/assignment.f.rs
+++ b/tests/output/comments/assignment.f.rs
@@ -302,5 +302,10 @@ fn foo() {
 
   let y = expr /* comment */
     .kaas()?;
+
+  (Foo {
+    // comment
+    ..a
+  } = a);
 }
 // source: "../../samples/comments/assignment.rs"

--- a/tests/output/comments/ignore.f.rs
+++ b/tests/output/comments/ignore.f.rs
@@ -96,7 +96,7 @@ const A {
 
 const A {
   // prettier-ignore
-  ..,
+  ..
 } = foo;
 
 const A {

--- a/tests/output/issues/0.f.rs
+++ b/tests/output/issues/0.f.rs
@@ -1379,7 +1379,7 @@ fn main() {
   let TestOutcome {
     completed: ok,
     errors: err,
-    ..,
+    ..
   } = forest.process_obligations(
     &mut C(
       |obligation| {
@@ -1811,7 +1811,7 @@ pub fn peel_blocks<'a>(mut expr: &'a Expr<'a>) -> &'a Expr<'a> {
         stmts: [],
         expr: Some(inner),
         rules: BlockCheckMode::DefaultBlock,
-        ..,
+        ..
       },
       _,
     ) = expr.kind
@@ -2245,8 +2245,39 @@ let mut Expect_Comma_after_first_match = match 0 {
     },
 };
 
-ExpectNoSpreadComma { ..a };
-ExpectNoSpreadComma { ..a };
-ExpectNoSpreadComma { a, b: b, ..c };
-ExpectNoSpreadComma { a, b: b, ..c };
+ExpectNoSpreadComma {
+  ..a //
+};
+ExpectNoSpreadComma {
+  ..a //
+};
+ExpectNoSpreadComma {
+  a,
+  b: b,
+  ..c //
+};
+ExpectNoSpreadComma {
+  a,
+  b: b,
+  ..c //
+};
+ExpectNoSpreadComma {
+  a, //
+  ..
+};
+ExpectNoSpreadComma {
+  .. //
+};
+
+let notify::event::Event {
+  kind: notify::event::EventKind::Modify(_),
+  paths,
+  ..
+} = event;
+
+let notify::event::Event {
+  kind: notify::event::EventKind::Modify(_),
+  paths,
+  ..
+} = event;
 // source: "../../samples/issues/0.rs"

--- a/tests/samples/comments/assignment.rs
+++ b/tests/samples/comments/assignment.rs
@@ -294,5 +294,10 @@ fn foo() {
             )
         });
 
-    let y = expr /* comment */.kaas()?
+    let y = expr /* comment */.kaas()?;
+
+    (Foo {
+        ..// comment
+        a
+    } = a);
 }

--- a/tests/samples/issues/0.rs
+++ b/tests/samples/issues/0.rs
@@ -1921,7 +1921,28 @@ let mut Expect_Comma_after_first_match = match 0 {
     },
 };
 
-ExpectNoSpreadComma { ..a };
-ExpectNoSpreadComma { ..a, };
-ExpectNoSpreadComma { a, b: b, ..c };
-ExpectNoSpreadComma { a, ..c, b: b };
+ExpectNoSpreadComma { ..a//
+};
+ExpectNoSpreadComma { ..a,//
+};
+ExpectNoSpreadComma { a, b: b, ..c//
+};
+ExpectNoSpreadComma { a, ..c,//
+b: b
+};
+ExpectNoSpreadComma { .., a//
+};
+ExpectNoSpreadComma { ..//
+};
+
+let notify::event::Event {
+    kind: notify::event::EventKind::Modify(_),
+    paths,
+    ..
+} = event;
+
+let notify::event::Event {
+    ..,
+    kind: notify::event::EventKind::Modify(_),
+    paths,
+} = event;


### PR DESCRIPTION
- (fix) Removes forbidden trailing comma after `..` in patterns and reassignments